### PR TITLE
テマキのversionを0.10.16でリリースする為

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "hrb-temaki",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
-    "version": "0.10.17",
+    "version": "0.10.16",
     "private": true,
     "license": "ISC",
     "scripts": {


### PR DESCRIPTION
作業時masterが16だったのでPRで17にしてmargeしていただいたが
16がリリースされてないようなので戻す