### PR TITLE
CIの速度改善

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
               - ./node_modules
       - run:
           name: Run test
-          command: yarn test --ci
+          command: yarn test --ci --maxWorkers=2
       - run:
           name: Run type check
           command: yarn type-check


### PR DESCRIPTION
`yarn test` の実行時間のみを比較

| やったこと | 速度 |
|:--:|:--:|
| 現状 | 10 ~ 13 minites |
| Jestのワーカー数をCircleCIのマシンのCPU数と同じ(2)にした | 20 ~ 40 seconds |